### PR TITLE
[#159663423] Gracefully handle vehicle not found situations.

### DIFF
--- a/lib/geotab/device.rb
+++ b/lib/geotab/device.rb
@@ -39,16 +39,20 @@ module Geotab
     def location
       result = device_status_infos.first
 
-      {
-        date: result.data.dateTime,
-        bearing: result.data.bearing,
-        current_state_duration: result.data.currentStateDuration,
-        is_device_communicating: result.data.isDeviceCommunicating,
-        is_driving: result.data.isDriving,
-        latitude: result.data.latitude,
-        longitude: result.data.longitude,
-        speed: result.data.speed
-      }
+      if result.present?
+        {
+          date: result.data.dateTime,
+          bearing: result.data.bearing,
+          current_state_duration: result.data.currentStateDuration,
+          is_device_communicating: result.data.isDeviceCommunicating,
+          is_driving: result.data.isDriving,
+          latitude: result.data.latitude,
+          longitude: result.data.longitude,
+          speed: result.data.speed
+        }
+      else
+        {}
+      end
     end
   end
 end


### PR DESCRIPTION
This can occur if a person imports a Geotab vehicle into your program and then they remove it from their Geotab account, and then you try to query for it via Geotab's API.